### PR TITLE
chore: adds entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,6 @@
     "doc": "jsdoc -c jsdoc.json src/*.js README.md",
     "push": "cd src; clasp push",
     "test": "mocha"
-  }
+  },
+  "exports": "./dist/OAuth2.gs"
 }


### PR DESCRIPTION
Fixes `Module not found: Error: Can't resolve 'OAuth2' in '/Users/.../src' [...] Field 'browser' doesn't contain a valid alias configuration` when trying to import this package as an ES module.